### PR TITLE
Concepts Cleanup

### DIFF
--- a/docs/concepts/data.md
+++ b/docs/concepts/data.md
@@ -1,22 +1,14 @@
 Datapacks
 =========
-In 1.13, Mojang added [datapacks][datapack] to the base game. They allow for the modification of the files placed under resources/data.
-This includes advancements, loot_tables, structures, recipes, tags, and more in the future.
-Forge, and your mod, are also datapacks. Any user can therefore modify all the recipes, loot tables, and other data of a mod just like with resource packs.
+In 1.13, Mojang added [datapacks][datapack] to the base game. They allow for the modification of the files for logical servers through the `data` directory. This includes advancements, loot_tables, structures, recipes, tags, etc. Forge, and your mod, can also have datapacks. Any user can therefore modify all the recipes, loot tables, and other data defined within this directory.
 
-Therefore, there is little sense in having configurable recipes or mob drops. Any user can modify them to any value (even from other mods).
-
-### Dev Environment
-In your project, you have a folder "resources" that has to contain a folder "data". This folder will be your datapack. 
-Your mod can have multiple data domains, since you can add or modify already existing datapacks, like vanilla's, forge's, or another mod's. 
+### Creating a Datapack
+Datapacks are stored within the `data` directory within your project's resources.
+Your mod can have multiple data domains, since you can add or modify already existing datapacks, like vanilla's, forge's, or another mod's.
+You can then follow the steps found [here][createdatapack] to create any datapack.
 
 Additional reading: [Resource Locations][resourcelocation]
 
-### Overriding Files
-To modify a datapack (be it the end user or in dev), you need to know the mod id and the registry name of the item/mob/advancement that you want to override. 
-These can be found after launching the mod (F3+h), but providing it for users in a simpler way can be helpful (using Github will allow users to navigate the datapack you provide with the mod).
-You can then follow the steps found [here][createdatapack] to create any datapack.
-
-[resourcelocation]: resources.md
 [datapack]: https://minecraft.gamepedia.com/Data_pack
 [createdatapack]: https://minecraft.gamepedia.com/Tutorials/Creating_a_data_pack
+[resourcelocation]: resources.md#ResourceLocation

--- a/docs/concepts/internationalization.md
+++ b/docs/concepts/internationalization.md
@@ -1,16 +1,16 @@
-Internationalization and localization
+Internationalization and Localization
 =====================================
 
 Internationalization, i18n for short, is a way of designing code so that it requires no changes to be adapted for various languages. Localization is the process of adapting displayed text to the user's language.
 
 I18n is implemented using _translation keys_. A translation key is a string that identifies a piece of displayable text in no specific language. For example, `block.minecraft.dirt` is the translation key referring to the name of the Dirt block. This way, displayable text may be referenced with no concern for a specific language. The code requires no changes to be adapted in a new language.
 
-Localization will happen in the game's locale. In a Minecraft client the locale is specified by the language settings. On a dedicated server, the only supported locale is en_US. A list of available locales can be found on the [Minecraft Wiki](https://minecraft.gamepedia.com/Language#Available_languages).
+Localization will happen in the game's locale. In a Minecraft client the locale is specified by the language settings. On a dedicated server, the only supported locale is `en_us`. A list of available locales can be found on the [Minecraft Wiki][langs].
 
 Language files
 --------------
 
-Language files are located by `assets/[namespace]/lang/[locale].json` (e.g. the US English translation for `examplemod` would be `assets/examplemod/lang/en_us.json`). The file format is simply a json map from translation keys to values. The file must be encoded in UTF-8. Old .lang files can be converted to json using a [converter][converter].
+Language files are located by `assets/[namespace]/lang/[locale].json` (e.g. all US English translations provided by `examplemod` would be within `assets/examplemod/lang/en_us.json`). The file format is simply a json map from translation keys to values. The file must be encoded in UTF-8. Old .lang files can be converted to json using a [converter][converter].
 
 ```json
 {
@@ -23,9 +23,9 @@ Language files are located by `assets/[namespace]/lang/[locale].json` (e.g. the 
 Usage with Blocks and Items
 ---------------------------
 
-Block, Item and a few other Minecraft classes have built-in translation keys used to display their names. These translation keys are specified by overriding `getTranslationKey()`. Item also has `getTranslationKey(ItemStack)` which can be overridden to provide different translation keys depending on ItemStack NBT.
+Block, Item and a few other Minecraft classes have built-in translation keys used to display their names. These translation keys are specified by overriding `#getTranslationKey`. Item also has `#getTranslationKey(ItemStack)` which can be overridden to provide different translation keys depending on ItemStack NBT.
 
-By default, `getTranslationKey()` will return `block.` or `item.` prepended to the registry name of the block or item, with the colon replaced by a dot. `ItemBlock`s will take their corresponding `Block`'s translation key by default. For example, an item with ID `examplemod:example_item` effectively requires the following line in a language file:
+By default, `#getTranslationKey` will return `block.` or `item.` prepended to the registry name of the block or item, with the colon replaced by a dot. `BlockItem`s override this method to take their corresponding `Block`'s translation key by default. For example, an item with ID `examplemod:example_item` effectively requires the following line in a language file:
 
 ```json
 {
@@ -61,4 +61,5 @@ The first parameter of the `TranslationTextComponent(String, Object...)` constru
 
 - `createComponentTranslation(ICommandSource, String, Object...)` creates a localized and formatted `TextComponent` depending on a receiver. The localization and formatting is done eagerly if the receiver is a vanilla client. If not, the localization and formatting is done lazily with a `TranslationTextComponent`. This is only useful if the server should allow vanilla clients to connect.
 
+[langs]: https://minecraft.gamepedia.com/Language#Available_languages
 [converter]: https://tterrag.com/lang2json/

--- a/docs/concepts/lifecycle.md
+++ b/docs/concepts/lifecycle.md
@@ -23,23 +23,23 @@ public class MyMod {
 ```
 
 !!! warning
-    The lifecycle events are fired in parallel: All mods will concurrently receive the same event.
+    Most of the lifecycle events are fired in parallel: all mods will concurrently receive the same event.
     
-    Mods *must* take care to be thread-safe, like when calling other mods' APIs or accessing vanilla systems. Defer code for later execution using the `DeferredWorkQueue` class.
+    Mods *must* take care to be thread-safe, like when calling other mods' APIs or accessing vanilla systems. Defer code for later execution via `ParallelDispatchEvent#enqueueWork`.
 
 Registry Events
 ---------------
 
-The `RegistryEvent`s are always the first to fire during mod loading, after the mod instance construction. There are two: the `NewRegistry` event and the `Register` event.
+The `RegistryEvent`s are fired after the mod instance construction. There are two: the `NewRegistry` event and the `Register` event. These events are fired synchronously during mod loading.
 
-The `RegistryEvent.NewRegistry` event allows modders to register their own custom registries, using the `RegistryBuilder` class.
+The `RegistryEvent$NewRegistry` event allows modders to register their own custom registries, using the `RegistryBuilder` class.
 
-The `RegistryEvent.Register<?>` event is for [registering objects][registering] into the registries. A `Register` event is fired for each registry. 
+The `RegistryEvent$Register<?>` event is for [registering objects][registering] into the registries. A `Register` event is fired for each registry. 
 
 Data Generation
 ---------------
 
-If the game is setup to run the [data generators][datagen], then the `GatherDataEvent` will be the last event to fire. This event is for registering mods' data providers to the data generators.
+If the game is setup to run [data generators][datagen], then the `GatherDataEvent` will be the last event to fire. This event is for registering mods' data providers to their associated data generator. This event is also fired synchronously.
 
 Common Setup
 ------------
@@ -54,14 +54,14 @@ The sided-setup events are fired on their respective [physical sides][sides]: `F
 InterModComms
 -------------
 
-This is where messages can be sent to mods for cross-mod compatibility. There are two events: the `InterModEnqueueEvent` and `InterModProcessEvent`.
+This is where messages can be sent to mods for cross-mod compatibility. There are two events: `InterModEnqueueEvent` and `InterModProcessEvent`.
 
-`InterModComms` is the class responsible for holding messages for mods. This class is safe to call during the lifecycle events, as it is backed by a `ConcurrentMap`.
+`InterModComms` is the class responsible for holding messages for mods. The methods are safe to call during the lifecycle events, as it is backed by a `ConcurrentMap`.
 
-During the `InterModEnqueueEvent`, use `InterModComms.sendTo` to send messages to different mods, then during the `InterModProcessEvent`, call `InterModComms.getMessages` to get a stream of all received messages.
+During the `InterModEnqueueEvent`, use `InterModComms#sendTo` to send messages to different mods, then during the `InterModProcessEvent`, call `InterModComms#getMessages` to get a stream of all received messages.
 
 !!! note
-    There is one last lifecycle event: the `FMLLoadCompleteEvent`, fired after the InterModComms events, for when the mod loading process is complete.
+    There are two other lifecycle events: `FMLConstructModEvent`, fired directly after mod instance construction but before the `RegistryEvent`s, and `FMLLoadCompleteEvent`, fired after the `InterModComms` events, for when the mod loading process is complete.
 
 [registering]: registries.md#methods-for-registering
 [capabilities]: ../datastorage/capabilities.md

--- a/docs/concepts/registries.md
+++ b/docs/concepts/registries.md
@@ -10,11 +10,11 @@ Every type of registrable object has its own registry. To see all registries sup
 Methods for Registering
 ------------------
 
-There are two proper ways to register objects: the `DeferredRegister` class, and the `RegistryEvent.Register` lifecycle event.
+There are two proper ways to register objects: the `DeferredRegister` class, and the `RegistryEvent$Register` lifecycle event.
 
 ### DeferredRegister
 
-`DeferredRegister` is the newer and documented way to register objects. It allows the use and convenience of static initializers while avoiding the issues associated with it. It simply maintains a list of suppliers for entries and registers the objects from those suppliers during the proper `RegistryEvent.Register` event.
+`DeferredRegister` is the newer and documented way to register objects. It allows the use and convenience of static initializers while avoiding the issues associated with it. It simply maintains a list of suppliers for entries and registers the objects from those suppliers during the proper `RegistryEvent$Register` event.
 
 An example of a mod registering a custom block:
 
@@ -32,7 +32,7 @@ public ExampleMod() {
 
 The `RegistryEvent`s are the second and more flexible way to register objects. These [events][] are fired after the mod constructors and before the loading of configs.
 
-The event used in registering objects is the `RegistryEvent.Register<T>`. The type parameter `T` should be set to the type of the object being registered. Calling `#getRegistry` will return the registry, upon which objects are registered with `#register` or `#registerAll`. 
+The event used to register objects is `RegistryEvent$Register<T>`. The type parameter `T` should be set to the type of the object being registered. Calling `#getRegistry` will return the registry, upon which objects are registered with `#register` or `#registerAll`. 
 
 Here is an example: (the event handler is registered on the *mod event bus*)
 
@@ -44,9 +44,9 @@ public void registerBlocks(RegistryEvent.Register<Block> event) {
 ```
 
 !!! note
-    Some classes cannot by themselves be registered; instead, `*Type` classes are registered, and used in the formers' constructors. For example, [`TileEntity`][tileentity] has `TileEntityType`, and `Entity` has `EntityType`. These `*Type` classes are factories that simply create the containing type on demand. 
+    Some classes cannot by themselves be registered. Instead, `*Type` classes are registered, and used in the formers' constructors. For example, [`TileEntity`][tileentity] has `TileEntityType`, and `Entity` has `EntityType`. These `*Type` classes are factories that simply create the containing type on demand. 
     
-    These factories are created through the use of their `*Type.Builder` classes. An example: (`REGISTER` refers to a `DeferredRegister<TileEntityType>`)
+    These factories are created through the use of their `*Type$Builder` classes. An example: (`REGISTER` refers to a `DeferredRegister<TileEntityType>`)
     ```java
     public static final RegistryObject<TileEntityType<ExampleTile>> EXAMPLE_TILE = REGISTER.register(
         "example_tile", () -> TileEntityType.Builder.create(ExampleTile::new, EXAMPLE_BLOCK.get()).build(null)
@@ -56,15 +56,15 @@ public void registerBlocks(RegistryEvent.Register<Block> event) {
 Referencing Registered Objects
 ------------------------------
 
-Registered objects should not be stored in fields when they are created and registered. They are to be always newly created and registered whenever their respective `RegistryEvent.Register` event is fired. This is to allow dynamic loading and unloading of mods in a future version of Forge.
+Registered objects should not be stored in fields when they are created and registered. They are to be always newly created and registered whenever their respective `RegistryEvent$Register` event is fired. This is to allow dynamic loading and unloading of mods in a future version of Forge.
 
 Registered objects must always be referenced through a `RegistryObject` or a field with `@ObjectHolder`.
 
 ### Using RegistryObjects
 
-`RegistryObject`s can be used to retrieve references to registered objects once they are available. These are used by `DeferredRegister` to return a reference to registered objects. Their references are updated after their corresponding registry's `RegistryEvent.Register` event is fired, along with the `@ObjectHolder` annotations.
+`RegistryObject`s can be used to retrieve references to registered objects once they are available. These are used by `DeferredRegister` to return a reference to the registered objects. Their references are updated after their corresponding registry's `RegistryEvent$Register` event is fired, along with the `@ObjectHolder` annotations.
 
-To get a `RegistryObject`, call `RegistryObject.of` with a `ResourceLocation` and the `IForgeRegistry` of the registrable object. Custom registries can also be used through giving a supplier of the object's class. Store the `RegistryObject` in a `public static final` field, and call `#get` whenever you need the registered object.
+To get a `RegistryObject`, call `RegistryObject#of` with a `ResourceLocation` and the `IForgeRegistry` of the registrable object. Custom registries can also be used by giving a supplier of the object's class. Store the `RegistryObject` in a `public static final` field, and call `#get` whenever you need the registered object.
 
 An example of using `RegistryObject`:
 
@@ -99,7 +99,7 @@ The rules for `@ObjectHolder` are as follows:
 * If no other errors or exceptions occur, the field will be injected
 * If all of the above rules do not apply, no action will be taken (and a message may be logged)
 
-`@ObjectHolder`-annotated fields are injected with their values after their corresponding registry's `RegistryEvent.Register` event is fired, along with the `RegistryObject`s.
+`@ObjectHolder`-annotated fields are injected with their values after their corresponding registry's `RegistryEvent$Register` event is fired, along with the `RegistryObject`s.
 
 !!! note
     If the object does not exist in the registry when it is to be injected, a debug message will be logged and no value will be injected.
@@ -184,11 +184,11 @@ class UnannotatedHolder { // Note the lack of an @ObjectHolder annotation on thi
 Creating Custom Registries
 -------------------
 
-Custom registries are created by using `RegistryBuilder` during the `RegistryEvent.NewRegistry` event. The class `RegistryBuilder` takes certain parameters (such as the name, the `Class` of its values, and various callbacks for different events happening on the registry). Calling `RegistryBuilder#create` will result in the registry being built, registered to the `RegistryManager`, and returned to the caller for additional processing.
+Custom registries are created by using `RegistryBuilder` during the `RegistryEvent$NewRegistry` event. The class `RegistryBuilder` takes certain parameters (such as the name, the `Class` of its values, and various callbacks for different events happening on the registry). Calling `RegistryBuilder#create` will result in the registry being built, registered to the `RegistryManager`, and returned to the caller for additional processing.
 
 The `Class` of the value of the registry must implement `IForgeRegistryEntry`, which defines that `#setRegistryName` and `#getRegistryName` can be called on the objects of that class. It is recommended to extend `ForgeRegistryEntry`, the default implementation instead of implementing the interface directly. When `#setRegistryName(String)` is called with a string, and that string does not have an explicit namespace, its namespace will be set to the current modid.
 
-The Forge registries can be accessed through the `ForgeRegistries` class. All registries, Forge-provided or custom, can be retrieved by calling `GameRegistry.findRegistry(Class)` with the appropriate class for the registry. For example, the registry for `Block`s can be retrieved by calling `GameRegistry.findRegistry(Block.class)`.
+The Forge registries can be accessed through the `ForgeRegistries` class. Any other registries can be stored and cached during their associated `RegistryEvent$Register`.
 
 [ResourceLocation]: resources.md#resourcelocation
 [events]: ../events/intro.md

--- a/docs/concepts/resources.md
+++ b/docs/concepts/resources.md
@@ -2,20 +2,20 @@ Resources
 =========
 
 A resource is extra data used by the game, and is stored in a data file, instead of being in the code. 
-Minecraft has two primary resource systems active: one on the client used for visuals such as models, textures, and localization called `assets`, the other used for gameplay such as recipes and loot tables called `data`.
-[Resource packs][respack] control the former, while [data packs][datapack] control the latter.
+Minecraft has two primary resource systems active: one on the logical client used for visuals such as models, textures, and localization called `assets`, and one on the logical server used for gameplay such as recipes and loot tables called `data`.
+[Resource packs][respack] control the former, while [Datapacks][datapack] control the latter.
 
 In the default mod development kit, assets and data directories are located under the `src/main/resources` directory of the project. 
 
-When multiple resource packs or data packs are enabled, they are merged. Generally, files from packs at the top of the stack override those below; however, for certain files, such as localization files and tags, data is actually merged contentwise. Mods actually define resource and data packs too, in their `resources` directories, but they are seen as subsets of the "Default" pack. Mod resource packs cannot be disabled, but they can be overridden by other resource packs. Mod datapacks can be disabled with the vanilla `/datapack` command.
+When multiple resource packs or data packs are enabled, they are merged. Generally, files from packs at the top of the stack override those below; however, for certain files, such as localization files and tags, data is actually merged contentwise. Mods define resource and data packs in their `resources` directories, but they are seen as subsets of the "Mod Resources" pack. Mod resource packs cannot be disabled, but they can be overridden by other resource packs. Mod datapacks can be disabled with the vanilla `/datapack` command.
 
 All resources should have snake case paths and filenames (lowercase, using "_" for word boundaries), which is enforced in 1.11 and above.
 
 `ResourceLocation`
 ------------------
 
-Minecraft identifies resources using `ResourceLocation`s. A `ResourceLocation` contains two parts: a namespace and a path. It generally points to the resource at `assets/<namespace>/<ctx>/<path>`, where `ctx` is a context-specific path fragment that depends on how the `ResourceLocation` is being used. When a `ResourceLocation` is written/read as/from a string, it is seen as `<namespace>:<path>`. If the namespace and the colon are left out, then when the string is read into an `ResourceLocation` the namespace will almost always default to `"minecraft"`. A mod should put its resources into a namespace with the same name as its modid (E.g. a mod with id `examplemod` should place its resources in `assets/examplemod`, and `ResourceLocation`s pointing to those files would look like `examplemod:<path>`.). This is not a requirement, and in some cases it can be desirable to use a different (or even more than one) namespace. `ResourceLocation`s are used outside the resource system, too, as they happen to be a great way to uniquely identify objects (e.g. [registries][]).
+Minecraft identifies resources using `ResourceLocation`s. A `ResourceLocation` contains two parts: a namespace and a path. It generally points to the resource at `assets/<namespace>/<ctx>/<path>`, where `ctx` is a context-specific path fragment that depends on how the `ResourceLocation` is being used. When a `ResourceLocation` is written/read as from a string, it is seen as `<namespace>:<path>`. If the namespace and the colon are left out, then when the string is read into an `ResourceLocation` the namespace will always default to `"minecraft"`. A mod should put its resources into a namespace with the same name as its modid (e.g. a mod with id `examplemod` should place its resources in `assets/examplemod` and `data/examplemod` respectively, and `ResourceLocation`s pointing to those files would look like `examplemod:<path>`.). This is not a requirement, and in some cases it can be desirable to use a different (or even more than one) namespace. `ResourceLocation`s are used outside the resource system, too, as they happen to be a great way to uniquely identify objects (e.g. [registries][]).
 
-[registries]: registries.md
-[datapack]: https://minecraft.gamepedia.com/Data_pack
 [respack]: https://minecraft.gamepedia.com/Resource_pack
+[datapack]: data.md
+[registries]: registries.md

--- a/docs/concepts/sides.md
+++ b/docs/concepts/sides.md
@@ -6,25 +6,25 @@ A very important concept to understand when modding Minecraft are the two sides:
 Different Kinds of Sides
 ------------------------
 
-When we say "client" or "server", it usually follows with a fairly intuitive understanding of what part of the game we're talking about. After all, a client is what the user interacts with, and a server is where the user connects for a multiplayer game. Easy, right?
+When we say "client" or "server", it usually follows with a fairly intuitive understanding of what part of the game we are talking about. After all, a client is what the user interacts with, and a server is where the user connects for a multiplayer game. Easy, right?
 
 As it turns out, there can be some ambiguity even with two such terms. Here we disambiguate the four possible meanings of "client" and "server":
 
 * Physical client - The *physical client* is the entire program that runs whenever you launch Minecraft from the launcher. All threads, processes, and services that run during the game's graphical, interactable lifetime are part of the physical client.
 * Physical server - Often known as the dedicated server, the *physical server* is the entire program that runs whenever you launch any sort of `minecraft_server.jar` that does not bring up a playable GUI.
-* Logical server - The *logical server* is what runs game logic: mob spawning, weather, updating inventories, health, AI, and all other game mechanics. The logical server is present within the physical server, but is also can run inside a physical client together with a logical client, as a single player world. The logical server always runs in a thread named the `Server Thread`.
+* Logical server - The *logical server* is what runs game logic: mob spawning, weather, updating inventories, health, AI, and all other game mechanics. The logical server is present within a physical server, but it also can run inside a physical client together with a logical client, as a single player world. The logical server always runs in a thread named the `Server Thread`.
 * Logical client - The *logical client* is what accepts input from the player and relays it to the logical server. In addition, it also receives information from the logical server and makes it available graphically to the player. The logical client runs in the `Client Thread`, though often several other threads are spawned to handle things like audio and chunk render batching.
 
-In the Minecraft codebase, the physical side is represented by an enum called `Dist`, while the logical side is represented by an enum called `LogicalSide`.
+In the MinecraftForge codebase, the physical side is represented by an enum called `Dist`, while the logical side is represented by an enum called `LogicalSide`.
 
 Performing Side-Specific Operations
 -----------------------------------
 
-### `world.isRemote`
+### `World#isRemote`
 
 This boolean check will be your most used way to check sides. Querying this field on a `World` object establishes the  **logical** side the world belongs to. That is, if this field is `true`, the world is currently running on the logical client. If the field is `false`, the world is running on the logical server. It follows that the physical server will always contain `false` in this field, but we cannot assume that `false` implies a physical server, since this field can also be `false` for the logical server inside a physical client (in other words, a single player world).
 
-Use this check whenever you need to determine if game logic and other mechanics should be run. For example, if you want to damage the player every time they click your block, or have your machine process dirt into diamonds, you should only do so after ensuring `world.isRemote` is `false`. Applying game logic to the logical client can cause desynchronization (ghost entities, desynchronized stats, etc.) in the lightest case, and crashes in the worst case.
+Use this check whenever you need to determine if game logic and other mechanics should be run. For example, if you want to damage the player every time they click your block, or have your machine process dirt into diamonds, you should only do so after ensuring `#isRemote` is `false`. Applying game logic to the logical client can cause desynchronization (ghost entities, desynchronized stats, etc.) in the best case, and crashes in the worst case.
 
 This check should be used as your go-to default. Aside from `DistExecutor`, rarely will you need the other ways of determining side and adjusting behavior.
 
@@ -40,13 +40,13 @@ How do we resolve this? Luckily, FML has `DistExecutor`, which provides various 
 
 ### Thread Groups
 
-If `Thread.currentThread().getThreadGroup() == SidedThreadGroups.SERVER` is true, it is likely the current thread is on the logical server. Otherwise, it is likely on the logical client. This is useful to retrieve the **logical** side when you do not have access to a `World` object to check `isRemote`. It *guesses* which logical side you are on by looking at the group of the currently running thread. Because it is a guess, this method should only be used when other options have been exhausted. In nearly every case, you should prefer checking `world.isRemote` to this check.
+If `Thread.currentThread().getThreadGroup() == SidedThreadGroups.SERVER` is true, it is likely the current thread is on the logical server. Otherwise, it is likely on the logical client. This is useful to retrieve the **logical** side when you do not have access to a `World` object to check `isRemote`. It *guesses* which logical side you are on by looking at the group of the currently running thread. Because it is a guess, this method should only be used when other options have been exhausted. In nearly every case, you should prefer checking `World#isRemote`.
 
-### `FMLEnvironment.dist` and `@OnlyIn`
+### `FMLEnvironment#dist` and `@OnlyIn`
 
-`FMLEnvironment.dist` holds the **physical** side your code is running on. Since it is determined at startup, it does not rely on guessing to return its result. The number of use cases for this is limited, however.
+`FMLEnvironment#dist` holds the **physical** side your code is running on. Since it is determined at startup, it does not rely on guessing to return its result. The number of use cases for this is limited, however.
 
-Annotating a method or field with the `@OnlyIn(Dist)` annotation indicates to the loader that the respective member should be completely stripped out of the definition not on the specified **physical** side. Usually, these are only seen when browsing through the decompiled Minecraft code, indicating methods that the Mojang obfuscator stripped out. There is little to no reason for using this annotation directly. Only use it if you are overriding a vanilla method that already has `@OnlyIn` defined. In most other cases where you need to dispatch behavior based on physical sides, use `DistExecutor` or a check on `FMLEnvironment.dist` instead.
+Annotating a method or field with the `@OnlyIn(Dist)` annotation indicates to the loader that the respective member should be completely stripped out of the definition not on the specified **physical** side. Usually, these are only seen when browsing through the decompiled Minecraft code, indicating methods that the Mojang obfuscator stripped out. There is **NO** reason for using this annotation directly. Use `DistExecutor` or a check on `FMLEnvironment#dist` instead.
 
 Common Mistakes
 ---------------
@@ -57,13 +57,13 @@ Whenever you want to send information from one logical side to another, you must
 
 This is actually very commonly inadvertently done through static fields. Since the logical client and logical server share the same JVM in a single player scenario, both threads writing to and reading from static fields will cause all sorts of race conditions and the classical issues associated with threading.
 
-This mistake can also be made explicitly by accessing physical client-only classes such as `Minecraft` from common code that runs or can run on the logical server. This mistake is easy to miss for beginners, who debug in a physical client. The code will work there, but will immediately crash on a physical server.
+This mistake can also be made explicitly by accessing physical client-only classes such as `Minecraft` from common code that runs or can run on the logical server. This mistake is easy to miss for beginners who debug in a physical client. The code will work there, but it will immediately crash on a physical server.
 
 
 Writing One-Sided Mods
 ----------------------
 
-In recent versions, Minecraft Forge has removed a "sidedness" attribute from the mods.toml. This means that your mods are expected to work whether they are loaded on the Client or on the Server. So for one-sided mods, you would typically register your event handlers inside a `DistExecutor.runWhenOn`, instead of directly calling the relevant registration methods in the constructor. Basically, if your mod is loaded on the wrong side, it should simply do nothing, listen to no events, and so on. A one-sided mod by nature should not register blocks, items, ... since they would need to be available on the other side, too.
+In recent versions, Minecraft Forge has removed a "sidedness" attribute from the mods.toml. This means that your mods are expected to work whether they are loaded on the physical client or the physical server. So for one-sided mods, you would typically register your event handlers inside a `DistExecutor#safeRunWhenOn` or `DistExecutor#unsafeRunWhenOn` instead of directly calling the relevant registration methods in your mod constructor. Basically, if your mod is loaded on the wrong side, it should simply do nothing, listen to no events, and so on. A one-sided mod by nature should not register blocks, items, ... since they would need to be available on the other side, too.
 
 Additionally, if your mod is one-sided, it typically does not forbid the user from joining a server that is lacking that mod. Therefore, you should override the `DISPLAYTEST` extension point to make sure that Forge does not think your mod is required on the server, which would lead to the server being shown as incompatible. For that, put something similar to this into your main mod class constructor:
 ```


### PR DESCRIPTION
This is a cleanup of the concepts folder to address any syntax, formatting, and outdated information in the docs.

- The `Resources` and `Data` pages are currently ambiguous. The information has been cleaned up to match their current design. However, a separate PR outside of omnibus should be done to properly cleanup and separate the information between the two.