### PR TITLE
Tile Cleanup

### DIFF
--- a/docs/tileentities/tesr.md
+++ b/docs/tileentities/tesr.md
@@ -1,14 +1,14 @@
 TileEntityRenderer
 ==================
 
-A `TileEntityRenderer` or `TER` (previously `TileEntitySpecialRenderer` or `TESR`) is used to render blocks in a way that cannot be represented with a static baked model (JSON, OBJ, B3D, others). A tile entity renderer requires the block to have a TileEntity.
+A `TileEntityRenderer` or `TER` (previously `TileEntitySpecialRenderer` or `TESR`) is used to render blocks in a way that cannot be represented with a static baked model (JSON, OBJ, B3D, others). A tile entity renderer requires the block to have a `TileEntity`.
 
 Creating a TER
 --------------
 
-To create a TER, create a class that inherits from `TileEntityRenderer`. It takes a generic argument specifying the block's TileEntity class. The generic argument is used in the TER's `render` method.
+To create a TER, create a class that inherits from `TileEntityRenderer`. It takes a generic argument specifying the block's `TileEntity` class. The generic argument is used in the TER's `render` method.
 
-Only one TER exists for a given tile entity. Therefore, values that are specific to a single instance in the world should be stored in the tile entity being passed to the renderer rather than in the TER itself. For example, an integer that increments every frame, if stored in the TER, will increment every frame for every tile entity of this type in the world.
+Only one TER exists for a given `TileEntityType`. Therefore, values that are specific to a single instance in the world should be stored in the tile entity being passed to the renderer rather than in the TER itself. For example, an integer that increments every frame, if stored in the TER, will increment every frame for every tile entity of this type in the world.
 
 ### `render`
 
@@ -25,4 +25,4 @@ This method is called every frame in order to render the tile entity.
 Registering a TER
 -----------------
 
-In order to register a TER, call `ClientRegistry#bindTileEntityRenderer` passing the tile entity class to be renderer with this TER and the instance of the TER to use to render all TEs of this class.
+In order to register a TER, call `ClientRegistry#bindTileEntityRenderer` passing the `TileEntityType` to be rendered with this TER and the instance of the TER used to render all TEs of this type.

--- a/docs/tileentities/tileentity.md
+++ b/docs/tileentities/tileentity.md
@@ -1,8 +1,8 @@
 # TileEntities
 
-Tile Entities are like simplified Entities, that are bound to a Block.
-They are used to store dynamic data, execute tick based tasks and for dynamic rendering.
-Some examples from vanilla Minecraft would be: handling of inventories (chests), smelting logic on furnaces, or area effects for beacons.
+`TileEntities` are like simplified `Entities` that are bound to a Block.
+They are used to store dynamic data, execute tick based tasks, and dynamic rendering.
+Some examples from vanilla Minecraft would be handling of inventories on chests, smelting logic on furnaces, or area effects on beacons.
 More advanced examples exist in mods, such as quarries, sorting machines, pipes, and displays.
 
 !!! note
@@ -11,9 +11,9 @@ More advanced examples exist in mods, such as quarries, sorting machines, pipes,
 
 ## Creating a `TileEntity`
 
-In order to create a `TileEntity` you need to extend the `TileEntity` class.
+In order to create a `TileEntity`, you need to extend the `TileEntity` class.
 To register it, listen for the appropriate registry event and create a `TileEntityType`:
-```Java
+```java
 @SubscribeEvent
 public static void registerTE(RegistryEvent.Register<TileEntityType<?>> evt) {
   TileEntityType<?> type = TileEntityType.Builder.create(factory, validBlocks).build(null);
@@ -21,23 +21,23 @@ public static void registerTE(RegistryEvent.Register<TileEntityType<?>> evt) {
   evt.getRegistry().register(type);
 }
 ```
-In this example, `factory` is a function that creates a new instance of your TileEntity. A method reference or a lambda is commonly used. The variable `validBlocks` is one or more blocks (`TileEntityType.Builder#create` is varargs) that the tile entity can exist for.
+In this example, `factory` is a function that creates a new instance of your TileEntity. A method reference or a lambda is commonly used. The variable `validBlocks` is one or more blocks (`TileEntityType$Builder#create` is varargs) that the tile entity can exist for.
 
 ## Attaching a `TileEntity` to a `Block`
 
-To attach your new `TileEntity` to a `Block` you need to override 2 (two) methods within the Block class.
-```JAVA
+To attach your new `TileEntity` to a `Block`, you need to override 2 (two) methods within your `Block` subclass:
+```java
 IForgeBlock#hasTileEntity(BlockState state)
 
 IForgeBlock#createTileEntity(BlockState state, IBlockReader world)
 ```
-Using the parameters you can choose if the block should have a `TileEntity` or not.
-Usually you will return `true` in the first method and a new instance of your `TileEntity` in the second method.
+Using the parameters, you can choose if the block should have a `TileEntity` or not.
+Usually, you will return `true` in the first method and a new instance of your `TileEntity` in the second method.
 
 ## Storing Data within your `TileEntity`
 
-In order to save data, override the following two methods
-```JAVA
+In order to save data, override the following two methods:
+```java
 TileEntity#write(CompoundNBT nbt)
 
 TileEntity#read(CompoundNBT nbt)
@@ -47,51 +47,47 @@ Use them to read and write to the fields in your tile entity class.
 
 !!! note
 
-		Whenever your data changes you need to call `TileEntity#markDirty()`, otherwise the `Chunk` containing your `TileEntity` might be skipped while the world is saved.
+		Whenever your data changes, you need to call `TileEntity#markDirty`; otherwise, the `Chunk` containing your `TileEntity` might be skipped while the world is saved.
 
 !!! important
 
-		It is important that you call the super methods!
-    The tag names `id`, `x`, `y`, `z`, `ForgeData` and `ForgeCaps` are reserved by the super methods.
+		It is important that you call the `super` methods!
+    The tag names `id`, `x`, `y`, `z`, `ForgeData` and `ForgeCaps` are reserved by the `super` methods.
 
 ## Ticking `TileEntities`
 
 If you need a ticking `TileEntity`, for example to keep track of the progress during a smelting process, you need to add the `net.minecraft.tileentity.ITickableTileEntity` interface to your `TileEntity`.
-Now you can implement all your calculations within
-```JAVA
-ITickableTileEntity#tick()
-```
+Now you can implement all your calculations within `ITickableTileEntity#tick`.
 
 !!! note
-    This method is called each tick, therefore you should avoid having complicated calculations in here.
-    If possible, you should make more complex calculations just every X ticks.
+    This method is called each tick; therefore, you should avoid having complicated calculations in here.
+    If possible, you should make more complex calculations every X ticks.
     (The amount of ticks in a second may be lower then 20 (twenty) but won't be higher)
 
 ## Synchronizing the Data to the Client
 
-There are 3 (three) ways of syncing data to the client.
-Synchronizing on chunk load, synchronizing on block updates and synchronizing with a custom network message.
+There are three ways of syncing data to the client: synchronizing on chunk load, on block updates, and with a custom network message.
 
-### Synchronizing on chunk load
+### Synchronizing on Chunk Load
 
 For this you need to override
-```JAVA
+```java
 TileEntity#getUpdateTag()
 
 IForgeTileEntity#handleUpdateTag(CompoundNBT nbt)
 ```
-Again, this is pretty simple, the first method collects the data that should be send to the client,
-while the second one processes that data. If your `TileEntity` doesn't contain much data you might be able to use the methods out of the [Storing Data within your `TileEntity`][storing-data] section.
+Again, this is pretty simple, the first method collects the data that should be sent to the client,
+while the second one processes that data. If your `TileEntity` doesn't contain much data, you might be able to use the methods out of the [Storing Data within your `TileEntity`][storing-data] section.
 
 !!! important
 
-    Synchronizing excessive/useless data for TileEntities can lead to network congestion. You should optimize your network usage by sending only the information the client needs when the client needs it. For instance, it is more often than not unnecessary to send the inventory of a tile entity in the update tag, as this can be synchronized via its GUI.
+    Synchronizing excessive/useless data for tile entities can lead to network congestion. You should optimize your network usage by sending only the information the client needs when the client needs it. For instance, it is more often than not unnecessary to send the inventory of a tile entity in the update tag, as this can be synchronized via its GUI.
 
-### Synchronizing on block update
+### Synchronizing on Block Update
 
-This method is a bit more complicated, but again you just need to override 2 methods.
-Here is a tiny example implementation of it
-```JAVA
+This method is a bit more complicated, but again you just need to override two methods.
+Here is a tiny example implementation of it:
+```java
 @Override
 public SUpdateTileEntityPacket getUpdatePacket(){
     CompoundNBT nbtTag = new CompoundNBT();
@@ -108,29 +104,29 @@ public void onDataPacket(NetworkManager net, SUpdateTileEntityPacket pkt){
 The Constructor of `SUpdateTileEntityPacket` takes:
 
 * The position of your `TileEntity`.
-* An ID, though it isn't really used besides by Vanilla, therefore you can just put a -1 in there.
+* An ID, though it isn't really used besides by Vanilla; therefore, you can just put a -1 in there.
 * An `CompoundNBT` which should contain your data.
 
 Now, to send the packet, an update notification must be given on the server.
-```JAVA
+```java
 World#notifyBlockUpdate(BlockPos pos, BlockState oldState, BlockState newState, int flags)
 ```
-The `pos` should be your TileEntitiy's position. For `oldState` and `newState` you can pass the current BlockState at that position.
-The `flags` are a bitmask and should contain `2`, which will sync the changes to the client. See `Constants.BlockFlags` for more info as well as the rest of the flags. The flag `2` is equivalent to `Constants.BlockFlags.BLOCK_UPDATE`.
+The `pos` should be your `TileEntity`'s position.
+For `oldState` and `newState`, you can pass the current `BlockState` at that position.
+`flags` is a bitmask that should contain `2`, which will sync the changes to the client. See `Constants$BlockFlags` for more info as well as the rest of the flags. The flag `2` is equivalent to `Constants$BlockFlags#BLOCK_UPDATE`.
 
-### Synchronizing using a custom network message
+### Synchronizing Using a Custom Network Message
 
-This way of synchronizing is probably the most complicated one, but is usually also the most optimized one,
+This way of synchronizing is probably the most complicated but is usually the most optimized,
 as you can make sure that only the data you need to be synchronized is actually synchronized.
 You should first check out the [`Networking`][networking] section and especially [`SimpleImpl`][simple_impl] before attempting this.
-Once you've created your custom network message, you can send it to all users that have the `TileEntity` loaded with `SimpleChannel#send(PacketDistributor.PacketTarget, MSG)`.
-
+Once you've created your custom network message, you can send it to all users that have the `TileEntity` loaded with `SimpleChannel#send(PacketDistributor$PacketTarget, MSG)`.
 
 !!! warning
 
-    It is important that you do safety checks, the TileEntity might already be destroyed/replaced when the message arrives at the player!
-    You should also check if the chunk is loaded (`World#isBlockLoaded(BlockPos)`)
+    It is important that you do safety checks, the `TileEntity` might already be destroyed/replaced when the message arrives at the player!
+    You should also check if the chunk is loaded (`World#isBlockLoaded(BlockPos)`).
 
+[storing-data]: #storing-data-within-your-tileentity
 [networking]: ../networking/index.md
 [simple_impl]: ../networking/simpleimpl.md
-[storing-data]: #storing-data-within-your-tileentity


### PR DESCRIPTION
This is a cleanup of the tileentities folder to address any syntax, formatting, and outdated information in the docs.

- TileEntities page is a bit outdated on explanation and should explain the point of the `TileEntityType` better. I know it's covered in registration, but these pages slightly neglect the point of it.