### PR TITLE
Utilities cleanup

### DIFF
--- a/docs/utilities/recipes.md
+++ b/docs/utilities/recipes.md
@@ -1,11 +1,11 @@
 Recipes
 =======
 
-With the update to Minecraft 1.12, Mojang introduced a new data-driven recipe system based on JSON files. Since then it has been adopted by Forge as well and was expanded in Minecraft 1.13 into [datapacks][datapack].
+With the update to Minecraft 1.12, Mojang introduced a new data-driven recipe system based on JSON files. Since then, it has been adopted by Forge and expanded in Minecraft 1.13 into [datapacks][datapack].
 
 Loading Recipes
 ---------------
-Forge will load all recipes which can be found within the `./data/<modid>/recipes/` folder. You can call these files whatever you want, thought the vanilla convention is to name them after the output item. For multiple recipes from different sources (Smelting, Crafting, etc) one vanilla convention is to use `item_name_from_smelting.json`. This name is also used as the registration key, but does not affect the operation of the recipe.
+Forge will load all recipes which can be found within the `./data/<modid>/recipes/` folder. You can call these files whatever you want, though the vanilla convention is to name them after the output item. For multiple recipes from different sources (Smelting, Crafting, etc), one vanilla convention is to use `item_name_from_smelting.json`. This name is also used as the registration key, but it does not affect the operation of the recipe.
 
 The Recipe file
 ---------------
@@ -29,50 +29,50 @@ A basic recipe file might look like the following example:
         },
         "a":
         {
-            "item": "mymod:myfirstitem",
+            "item": "mymod:myfirstitem"
         }
     },
     "result":
     {
         "item": "mymod:myitem",
-        "count": 9,
+        "count": 9
     }
 }
 ```
 
 !!! note
 
-    When you first obtain an ingredient to a vanilla recipe it will automatically unlock the recipe in the recipe book. To achieve the same effect, you have to use the [`Advancement`][Advancements] system and create a new `Advancement` for each of your ingredients.
+    When you first obtain an ingredient to a vanilla recipe, it will automatically unlock the recipe in the recipe book. To achieve the same effect, you have to use the [advancement][] system and create a new advancement for each of your ingredients.
 
-    The advancement has to exist. This doesn't mean it has to be visible in the advancement tree.
+    The advancement has to exist. This does not mean it has to be visible in the advancement tree.
 
 ### Type
 
-The type of a recipe with the type field. You can think of this as the definition of which crafting layout is to be used, for example `minecraft:crafting_shaped` or `minecraft:crafting_shapeless`.
+The type of a recipe is specified via the `type` field. You can think of this as the definition of which recipe layout to use, for example `minecraft:crafting_shaped` or `minecraft:crafting_shapeless`.
 
 ### Groups
 
-Optionally you can add a group to your recipes to be displayed within the recipe helper interface. All recipes with the same group String will be shown in the same group. For example, this can be used to have all door recipes shown in the recipe helper interface as a single entry, even though there are different types of doors.
+Optionally, you can add a group to your recipes to be displayed within the recipe helper interface. All recipes with the same group string will be shown in the same group. For example, this can be used to have all door recipes shown in the recipe helper interface as a single entry, even though there are different types of doors.
 
 Types of crafting recipes
 -----------------------------
-Within this section we will take a closer look on the differences between defining a shaped and a shapeless crafting recipe.
+Within this section, we will take a closer look on the differences between defining a shaped and a shapeless crafting recipe.
 
 ### Shaped crafting
 
-Shaped recipes require the `pattern` and `key` keywords. A pattern defines the slot an item must appear in using placeholder characters. You can choose whatever character you want to be a placeholder for an item. Keys on the other hand define what items are to be used instead of the placeholders. A key is defined by a placeholder character and the item.
+Shaped recipes require the `pattern` and `key` keywords. A pattern defines the slot an item must appear in using placeholder characters. You can choose whatever character you want to be a placeholder for an item. The whitespace character is reserved for an empty slot. Keys, on the other hand, define what items to use for the placeholders. A key is defined by a placeholder character and the item.
 
 ### Shapeless crafting
 
-A shapeless recipe doesn't make use of the `pattern` and `key` keywords.
+A shapeless recipe does not make use of the `pattern` and `key` keywords.
 
-To define a shapeless recipe, you have to use the `ingredients` list. It defines which items have to be used for the crafting process. There are [many more][Wiki] of these types which can be used here and you can even register your own. It is even possible to define multiple instances of the same item which means multiple of these items have to be in place for the crafting recipe to take place.
+To define a shapeless recipe, you have to use the `ingredients` list. It defines which items have to be used for the crafting process. There are [many more][wiki] of these types which can be used here, and you can even register your own. It is even possible to define a slot that requires more than one of an item, which means multiple of these items have to be in place.
 
 !!! note
 
-    While there is no limit on how many ingredients your recipe requires the vanilla crafting table does only allow 9 items to be placed for each crafting recipe.
+    While there is no limit on how many ingredients your recipe requires, the vanilla crafting table only allows 9 items to be placed for each crafting recipe.
 
-The following example shows how an ingredient list looks like within JSON.
+The following example shows how an ingredient list looks like within JSON:
 
 ```json
     "ingredients": [
@@ -83,38 +83,15 @@ The following example shows how an ingredient list looks like within JSON.
             "item": "minecraft:nether_star"
         }
     ],
-```
-
-Recipe Elements
----------------
-
-### Patterns
-
-A pattern will be defined with the `pattern` list. Each string represents one row in the crafting grid and each placeholder character within the String represents a column. As seen in the example above a space means that no item needs to be inserted at that position.
-
-### Keys
-
-A key set is used in combination with patterns and contains keys whose name is the same as the placeholder character in the pattern list which it represents. One key may be defined to represent multiply items as it is the case for the wooden button. This means that the player can use one of the defined items for the crafting recipe, for example different types of wood.
-
-```json
-  "key": {
-     "#": [
-      {
-        "item": "minecraft:oak_planks"
-      },
-      {
-        "item": "minecraft:spruce_planks"
-      }
-    ]
-  }
+    ...
 ```
 
 ### Results
 
-Every `recipe` has to have a result tag to define the output item.
+Every vanilla recipe has to have a `result` tag to define the output item.
 
-When crafting something, you can get out more than one item. This is achieved by defining the `count` number. If this is left out, meaning it doesn't exist within the result block, it defaults to 1. Negative values are not allowed here as an ItemStack cannot be smaller than 0. There is no option to use the `count` number anywhere else than for the result.
+When crafting something, you can get out more than one item. This is achieved by defining the `count` number. If this is left out, meaning it doesn't exist within the result block, it defaults to 1. Negative values are not allowed here as an `ItemStack` cannot be smaller than 0. There is no option to use the `count` number anywhere else than for the result. Forge also added support for results to include NBT data via the `nbt` tag.
 
-[Advancements]: https://minecraft.fandom.com/wiki/Advancement
-[Wiki]: https://minecraft.gamepedia.com/Recipe
 [datapack]: /concepts/data.md
+[advancement]: https://minecraft.fandom.com/wiki/Advancement
+[wiki]: https://minecraft.gamepedia.com/Recipe

--- a/docs/utilities/tags.md
+++ b/docs/utilities/tags.md
@@ -1,11 +1,11 @@
 Tags
 ====
 
-Tags are generalized sets of objects in the game, used for grouping related things together and providing fast membership checks.
+Tags are generalized sets of objects in the game used for grouping related things together and providing fast membership checks.
 
 Declaring Your Own Groupings
 ----------------------------
-Tags are declared in your mod's [datapack][datapack]. For example, `/data/modid/tags/blocks/foo/tagname.json` will declare a `Tag<Block>` with ID `modid:foo/tagname`.
+Tags are declared in your mod's [datapack][datapack]. For example, `/data/<modid>/tags/blocks/foo/tagname.json` will declare a `Tag<Block>` with ID `modid:foo/tagname`.
 Similarly, you may append to or override tags declared in other domains, such as Vanilla, by declaring your own JSONs.
 For example, to add your own mod's saplings to the Vanilla sapling tag, you would specify it in `/data/minecraft/tags/blocks/saplings.json`, and Vanilla will merge everything into one tag at reload, if the `replace` option is false.
 If `replace` is true, then all entries before the json specifying `replace` will be removed.
@@ -21,50 +21,52 @@ Using Tags In Code
 ------------------
 Block, Item, and Fluid tags are automatically sent from the server to any remote clients on login and reload. Function tags are not synced.
 
-`BlockTags.getCollection()` and `ItemTags.getCollection()` will retrieve the current `TagCollection`, from which you can retrieve a `Tag` object by its ID.
+`BlockTags#getCollection` and `ItemTags#getCollection` will retrieve the current `TagCollection`, from which you can retrieve a `Tag` object by its ID.
 With a `Tag` object in hand, membership can be tested with `tag.contains(thing)`, or all the objects in the tag queried with `tag.getAllElements()`.
 
 As an example:
-```Java
-ResourceLocation myTagId = new ResourceLocation("mymod", "myitemgroup");
+```java
+public static final Tag<Item> myTag = new ItemTags.Wrapper(new ResourceLocation("mymod", "myitemgroup"));
+
+// In some method
 Item unknownItem = stack.getItem();
-boolean isInGroup = ItemTags.getCollection().getOrCreateTag(myTagId).contains(unknownItem);
-// alternatively, can use getTag and perform a null check
+boolean isInGroup = unknownItem.isIn(myTag);
 ```
 
 !!! note:
-    The `TagCollection` returned by `getCollection()` (and the `Tag`s within it) may expire if a reload happens, so you should always query the collection anew every time you need it.
+    The `TagCollection` returned by `getCollection()` (and the `Tag`s within it) may expire if a reload happens.
     The static `Tag` fields in `BlockTags` and `ItemTags` avoid this by introducing a wrapper that handles this expiring.
-    Alternatively, a resource reload listener can be used to refresh any cached tags.
 
 
 Conventions
 -----------
 
 There are several conventions that will help facilitate compatibility in the ecosystem:
-* If there is a Vanilla tag that fits your block or item, add it to that tag. See the [list of Vanilla tags](https://minecraft.gamepedia.com/Tag#List_of_tags).
-* If there is a Forge tag that fits your block or item, add it to that tag. The list of tags declared by Forge can be seen on [GitHub](https://github.com/MinecraftForge/MinecraftForge/tree/1.14.x/src/generated/resources/data/forge/tags).
-* If there is a group of something you feel should be shared by the community, consider PR-ing it to Forge instead of making your own tag
-* Tag naming conventions should follow Vanilla conventions. In particular, item and block groupings are plural instead of singular. E.g. `minecraft:logs`, `minecraft:saplings`.
-* Item tags should be sorted into subdirectories according to the type of item, e.g. `forge:ingots/iron`, `forge:nuggets/brass`, etc.
+* If there is a Vanilla tag that fits your block or item, add it to that tag. See the [list of Vanilla tags][taglist].
+* If there is a Forge tag that fits your block or item, add it to that tag. The list of tags declared by Forge can be seen on [GitHub][forgetags].
+* If there is a group of something you feel should be shared by the community, use the `forge` namespace instead of your mod id.
+* Tag naming conventions should follow Vanilla conventions. In particular, item and block groupings are plural instead of singular (e.g. `minecraft:logs`, `minecraft:saplings`).
+* Item tags should be sorted into subdirectories according to their type (e.g. `forge:ingots/iron`, `forge:nuggets/brass`, etc.).
 
 
 Migration from OreDictionary
 ----------------------------
 
-* For recipes, tags can be used directly in the vanilla recipe format (see below)
+* For recipes, tags can be used directly in the vanilla recipe format (see below).
 * For matching items in code, see the section above.
 * If you are declaring a new type of item grouping, follow a couple naming conventions:
   * Use `domain:type/material`. When the name is a common one that all modders should adopt, use the `forge` domain.
-  * For example, brass ingots should be registered under the `forge:ingots/brass` tag, and cobalt nuggets under the `forge:nuggets/cobalt` tag.
+  * For example, brass ingots should be registered under the `forge:ingots/brass` tag and cobalt nuggets under the `forge:nuggets/cobalt` tag.
 
 
 Using Tags in Recipes and Advancements
 --------------------------------------
 
-Tags are directly supported by Vanilla, see the respective Vanilla wiki pages for [recipes][] and [advancements][] for usage details.
+Tags are directly supported by Vanilla. See the respective Vanilla wiki pages for [recipes][] and [advancements][] for usage details.
 
+[datapack]: ../concepts/data.md
 [tags]: https://minecraft.gamepedia.com/Tag#JSON_format
+[taglist]: https://minecraft.gamepedia.com/Tag#List_of_tags
+[forgetags]: https://github.com/MinecraftForge/MinecraftForge/tree/1.15.x/src/generated/resources/data/forge/tags
 [recipes]: https://minecraft.gamepedia.com/Recipe#JSON_format
 [advancements]: https://minecraft.gamepedia.com/Advancements
-[datapack]: /concepts/data.md


### PR DESCRIPTION
This is a cleanup of the utilities folder to address any syntax, formatting, and outdated information in the docs. This addresses the one colon wonder of #368 as well.

- There will be another PR to address the Tag rewrite for 1.16.
- Utilities need an overhaul in general after omnibus since most of the information is quite unsubstantial and non-beneficial compared to the regular wiki.