### PR TITLE
Effects Cleanup

### DIFF
--- a/docs/effects/particles.md
+++ b/docs/effects/particles.md
@@ -14,17 +14,17 @@ Terminology
 Different Particles
 -------------------
 
-You will need to have your own implementation of the `Particle` class, which will handle the rendering of the particle. Vanilla examples will help you on how to handle rendering, this guide will not get into that and only discuss the logic part of particles.
+You will need to have your own implementation of the `Particle` class which will handle the rendering of the particle. Vanilla examples will help you on how to handle rendering. This guide will not get into that and instead only discuss the logic part.
 
 ### Sidedness
-The `Particle` class is [**client only**][sides], it does not exist on the server. This means that creating a fixed parameter particle (no context information needed) is somewhat simpler, more on that later. However, if the particle has a parameter with dynamic values, server information is required. For example, breaking blocks create a particle effect based on the broken block's texture. This information obviously depends on the `Blockstate` of the block, which is taken from the server.
+The `Particle` class is [**client only**][sides]; it does not exist on the server. This means that creating a fixed parameter particle is somewhat simpler, more on that later. However, if the particle has a parameter with dynamic values, server information is required. For example, breaking blocks create a particle effect based on the broken block's texture. This information obviously depends on the `Blockstate` of the block, which is taken from the server.
 
 To make a particle appear, use either `ClientWorld#addParticle` or
-`ServerWorld#spawnParticle`. `ServerWorld#addParticle` will simply do nothing, without throwing any errors.
+`ServerWorld#spawnParticle`. `ServerWorld#addParticle` will simply do nothing without throwing any errors.
 
 ### Does your particle need server data?
-Taking as an example a mod which adds some spells to the game: If there's 8 type of spells added with each one specific color, there is no need for server information. Each spell will have a distinct registered `ParticleType`. 
-However, if these spells can have modifiers that can affect the color in multiple ways (add/subtract red/green/blue data) then having a registry object for each combination will be tedious. In that case, server information will be required when spawning the particle, to calculate the color to use.
+Taking as an example a mod which adds some spells to the game: If there are 8 types of spells added with each one specific color, there is no need for server information. Each spell will have a distinct, registered `ParticleType`. 
+However, if these spells can have modifiers that can affect the color in multiple ways (add/subtract red/green/blue data), then having a registry object for each combination will be tedious. In that case, server information will be required when spawning the particle to calculate the color to use.
 
 ParticleTypes
 -------------
@@ -41,7 +41,7 @@ IParticleFactory
 ----------------
 
 To tie up everything, you need to implement an `IParticleFactory`. One factory needs to be registered for every `ParticleType` you register. 
-When covering discrete cases, you can specify a parameter in the constructor, to be able to differentiate the cases.
+When covering discrete cases, you can specify a parameter in the constructor to be able to differentiate the cases.
 ```java
 public static class Factory implements IParticleFactory<BasicParticleType> {
   private final Color color;
@@ -56,20 +56,24 @@ public static class Factory implements IParticleFactory<BasicParticleType> {
   }
 }
 ```
-In the example above, a `Color` can be specified during registration. The downside is the colors are "hardcoded" and can't be changed using the /particle command. However, adding a new distinct case is easy, there only needs to be a new `ParticleType` and the associated factory. Finally, `IParticleFactory` has one method, `#makeParticle`, which returns a `Particle`. You can then return a new instance of your particle as shown above. If you are using a `BasicParticleType`, that parameter will be unused.
+In the example above, a `Color` can be specified during registration. The downside is the colors are "hardcoded" and can't be changed using the `/particle` command. However, adding a new distinct case is easy, there only needs to be a new `ParticleType` and the associated factory. Finally, `IParticleFactory` has one method, `#makeParticle`, which returns a `Particle`. You can then return a new instance of your particle as shown above. If you are using a `BasicParticleType`, that parameter will be unused.
 
 #### Registering
-Factories need to be added to the `ParticleManager`. The `ParticleFactoryRegisterEvent` is fired when you should do so. At that point use: `Minecraft.getInstance()#particles#registerFactory()` to register your factory. It needs a `ParticleType` (from it, it will get the registry name) and an instance of your `IParticleFactory`. When registering discrete valued particles, the factory will contain the discrete information, like so pertaining to the previous example:
+Factories need to be added to the `ParticleManager` using the `ParticleFactoryRegisterEvent`. At that point use: `ParticleManager#registerFactory` to register your factory. It needs a `ParticleType` (from it, it will get the registry name) and an instance of your `IParticleFactory`. When registering discrete valued particles, the factory will contain the discrete information, like so pertaining to the previous example:
 ```java 
 Minecraft.getInstance().particles.registerFactory(DeferredRegistration.HEART_CRYSTAL_PARTICLE.get(), new SHParticle.Factory(Color.FIREBRICK));
 Minecraft.getInstance().particles.registerFactory(DeferredRegistration.POWER_CRYSTAL_PARTICLE.get(), new SHParticle.Factory(Color.ROYALBLUE));
 ```
 The interest in doing this is to avoid having to deal with `IParticleData` and not create multiple `Particle` implementations for each color.
 
+!!! warning
+
+  If you are using an animated sprite set for your `Particle` with its associated JSON, you will need to register an `IParticleMetaFactory` instead. Otherwise, you will throw an `IllegalStateException`.
+
 !!! important
 
   `IParticleFactory` is [**client only**][sides], like the `Particle` class. A way of dealing with this is using a handler class and the `EventBusSubscriber` annotation with a dist value.
 
-[registration]: ../concepts/registries.md#registering-things
 [sides]: ../concepts/sides.md
 [servdat]: #does-your-particle-need-server-data
+[registration]: ../concepts/registries.md#registering-things

--- a/docs/effects/sounds.md
+++ b/docs/effects/sounds.md
@@ -6,26 +6,24 @@ Terminology
 
 | Term | Description |
 |----------------|----------------|
-|  Sound Events  | Something that triggers a sound effect. Examples include `"minecraft:block.anvil.hit"` or `"botania:spreaderFire"`. |
-| Sound Category | The category of the sound, for example `"player"`, `"block"` or simply `"master"`. The sliders in the sound settings GUI represent these categories. |
-|   Sound File   | The literal file on disk that is played, usually an .ogg file. |
+|  Sound Events  | Something that triggers a sound effect. Examples include `minecraft:block.anvil.hit` or `botania:spreader_fire`. |
+| Sound Category | The category of the sound, for example `player`, `block` or simply `master`. The sliders in the sound settings GUI represent these categories. |
+|   Sound File   | The literal file on disk that is played: an .ogg file. |
 
 `sounds.json`
 -------------
 
-This JSON defines sound events, and defines which sound files they play, the subtitle, etc. Sound events are identified with [`ResourceLocation`][ResourceLocation]s. `sounds.json` should be located at the root of a resource namespace (`assets/<namespace>/sounds.json`), and it defines sound events in that namespace (`assets/<namespace>/sounds.json` defines sound events in the namespace `namespace`.).
+This JSON defines sound events, and defines which sound files they play, the subtitle, etc. Sound events are identified with [`ResourceLocation`][loc]s. `sounds.json` should be located at the root of a resource namespace (`assets/<namespace>/sounds.json`), and it defines sound events in that namespace (`assets/<namespace>/sounds.json` defines sound events in the namespace `namespace`.).
 
 A full specification is available on the vanilla [wiki][], but this example highlights the important parts:
 
 ```json
 {
   "open_chest": {
-    "category": "block",
-    "subtitle": "mymod.subtitle.openChest",
+    "subtitle": "mymod.subtitle.open_chest",
     "sounds": [ "mymod:open_chest_sound_file" ]
   },
   "epic_music": {
-    "category": "record",
     "sounds": [
       {
         "name": "mymod:music/epic_music",
@@ -36,9 +34,9 @@ A full specification is available on the vanilla [wiki][], but this example high
 }
 ```
 
-Underneath the top-level object, each key corresponds to a sound event. Note that the namespace is not given, as it is taken from the namespace of the JSON itself. Each event specifies its category, and a localization key to be shown when subtitles are enabled. Finally, the actual sound files to be played are specified. Note that the value is an array; if multiple sound files are specified then the game will randomly choose one to play whenever the sound event is triggered.
+Underneath the top-level object, each key corresponds to a sound event. Note that the namespace is not given, as it is taken from the namespace of the JSON itself. Each event specifies a localization key to be shown when subtitles are enabled. Finally, the actual sound files to be played are specified. Note that the value is an array; if multiple sound files are specified, the game will randomly choose one to play whenever the sound event is triggered.
 
-The two examples represent two different ways to specify a sound file. The [wiki][] has precise details, but generally, long sound files such as BGM or music discs should use the second form, because the "stream" argument tells Minecraft to not load the entire sound file into memory but to stream it from disk. The second form can also specify the volume, pitch, and random weight of a sound file.
+The two examples represent two different ways to specify a sound file. The [wiki][] has precise details, but generally, long sound files such as background music or music discs should use the second form, because the "stream" argument tells Minecraft to not load the entire sound file into memory but to stream it from disk. The second form can also specify the volume, pitch, and weight of a sound file.
 
 In all cases, the path to a sound file for namespace `namespace` and path `path` is `assets/<namespace>/sounds/<path>.ogg`. Therefore `mymod:open_chest_sound_file` points to `assets/mymod/sounds/open_chest_sound_file.ogg`, and `mymod:music/epic_music` points to `assets/mymod/sounds/music/epic_music.ogg`.
 
@@ -47,22 +45,12 @@ Creating Sound Events
 
 In order to actually be able to play sounds, a `SoundEvent` corresponding to an entry in `sounds.json` must be created. This `SoundEvent` must then be [registered][registration]. Normally, the location used to create a sound event should be set as it's registry name.
 
-Creating a `SoundEvent`:
-
-```java
-ResourceLocation location = new ResourceLocation("mymod", "open_chest");
-SoundEvent event = new SoundEvent(location);
-```
-
-The `SoundEvent` acts as a reference to the sound, and is passed around to actually play sounds. Therefore, the `SoundEvent` should be stored somewhere. If a mod has an API, it should expose its `SoundEvent`s in the API.
+The `SoundEvent` acts as a reference to the sound and is passed around to play them. If a mod has an API, it should expose its `SoundEvent`s in the API.
 
 Playing Sounds
 --------------
 
-Vanilla has lots of methods for playing sounds, and it's unclear which to use at times.
-
-!!! Note
-    This information was gathered by looking at these various methods, analyzing their usage and categorizing them accordingly. It is up-to-date as of Forge 1907, please let someone know if it is out of date!
+Vanilla has lots of methods for playing sounds, and it is unclear which to use at times.
 
 Note that each takes a `SoundEvent`, the ones registered above. Additionally, the terms *"Server Behavior"* and *"Client Behavior"* refer to the respective [**logical** side][sides].
 
@@ -74,7 +62,7 @@ Note that each takes a `SoundEvent`, the ones registered above. Additionally, th
 2. <a name="world-playsound-pxyzecvp"></a> `playSound(PlayerEntity, double x, double y, double z, SoundEvent, SoundCategory, volume, pitch)`
     - **Client Behavior**: If the passed in player is *the* client player, plays the sound event to the client player.
     - **Server Behavior**: Plays the sound event to everyone nearby **except** the passed in player. Player can be `null`.
-    - **Usage**: The correspondence between the behaviors implies that these two methods are to be called from some player-initiated code that will be run on both logical sides at the same time - the logical client handles playing it to the user and the logical server handles everyone else hearing it without re-playing it to the original user.
+    - **Usage**: The correspondence between the behaviors implies that these two methods are to be called from some player-initiated code that will be run on both logical sides at the same time: the logical client handles playing it to the user, and the logical server handles everyone else hearing it without re-playing it to the original user.
        They can also be used to play any sound in general at any position server-side by calling it on the logical server and passing in a `null` player, thus letting everyone hear it.
 
 3. <a name="world-playsound-xyzecvpd"></a> `playSound(double x, double y, double z, SoundEvent, SoundCategory, volume, pitch, distanceDelay)`
@@ -111,7 +99,7 @@ Note that each takes a `SoundEvent`, the ones registered above. Additionally, th
     - **Server Behavior**: Method is client-only.
     - **Usage**: Just like the ones in `World`, these two overrides in the player classes seem to be for code that runs together on both sides. The client handles playing the sound to the user, while the server handles everyone else hearing it without re-playing to the original user.
 
+[loc]: ../concepts/resources.md#resourcelocation
 [wiki]: https://minecraft.gamepedia.com/Sounds.json
 [registration]: ../concepts/registries.md#methods-for-registering
-[ResourceLocation]: ../concepts/resources.md#resourcelocation
 [sides]: ../concepts/sides.md


### PR DESCRIPTION
This is a cleanup of the effects folder to address any syntax, formatting, and outdated information in the docs.

- Partially addresses #358 until rewrite.
- The data within this folder should be overhauled and explained thoroughly. Currently, they are more shallow tutorials than actual documentation.