### PR TITLE
Hide Animation API

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,10 +18,10 @@ nav:
     - Home: 'blocks/blocks.md'
     - Blockstates: 'blocks/states.md'
     - Interaction: 'blocks/interaction.md'
-  - Animation API:
-    - Intro to the Animation API: 'animation/intro.md'
-    - Armatures: 'animation/armature.md'
-    - Animation State Machines: 'animation/asm.md'
+#  - Animation API:
+#    - Intro to the Animation API: 'animation/intro.md'
+#    - Armatures: 'animation/armature.md'
+#    - Animation State Machines: 'animation/asm.md'
 #    - Using the API: 'animation/implementing.md'
   - Tile Entities:
     - Home: 'tileentities/tileentity.md'


### PR DESCRIPTION
Since the animation API is pretty much dead but still lives in the Forge codebase, the solution would be to hide the pages and then remove when Forge 'officially' removes it from their framework. If somebody in-between then wants to revamp the docs into a workable state, all the better.