### PR TITLE
Conventions Cleanup

### DIFF
--- a/docs/conventions/loadstages.md
+++ b/docs/conventions/loadstages.md
@@ -1,10 +1,10 @@
 Loading Stages
 ==============
 
-The Forge loading process has four main phases. All of these events shown are fired on the mod-specific eventbus, *not* the global Forge event bus `MinecraftForge.EVENT_BUS`
-Handlers should be registered either using `@EventBusSubscriber(bus = Bus.MOD)` or in the mod object constructor as follows:
+The Forge loading process has four main phases. All of these events shown are fired on the mod-specific eventbus, *not* the global Forge event bus `MinecraftForge#EVENT_BUS`.
+Event handlers should be [registered][regevents]:
 
-```Java
+```java
 @Mod("mymod")
 public class MyMod {
   public MyMod() {
@@ -23,29 +23,26 @@ public class MyMod {
 
 ## Setup
 
-`FMLCommonSetupEvent` is the first to fire, and is fired early in the Minecraft starting process.
+`FMLCommonSetupEvent` is the first to fire early in the Minecraft starting process.
 [Registry events][registering] are fired before this event, so you can expect all registry objects to be valid by the time this runs.
 Common actions to perform in common setup are:
 
-  * Creating and reading the config files
+  * Utilizing the common config data
   * Registering [Capabilities][capabilities]
 
 ## Sided Setup
 
-`FMLClientSetupEvent` and `FMLDedicatedServerSetupEvent` are fired after common setup, and are where physical side-specific initialization should occur.
+`FMLClientSetupEvent` and `FMLDedicatedServerSetupEvent` are fired after common setup, and are where physical, side-specific initialization should occur.
 Common actions to perform here are registering client-side only things such as key bindings.
 
 ## IMC Enqueue
 
-Here, mods should send messages to all other mods they are interested in integrating with, using the `InterModComms.sendTo()` method.
+Here, mods should send messages to all other mods they are interested in integrating with, using `InterModComms#sendTo`.
 
 ## IMC Process
 
-Here, mods should process all the messages they have received from other mods and set up integrations appropriately. A mod may retrieve the messages that have been sent to it using the `InterModComms.getMessages()` method.
+Here, mods should process all the messages they have received from other mods and set up integrations appropriately. A mod may retrieve the messages that have been sent to it using `#getIMCStream` located within the event.
 
-##Other Important Events
-
-  * `FMLServerStartingEvent`: Register Commands
-
+[regevents]: ../events/intro.md#creating-an-event-handler
 [registering]: ../concepts/registries.md#registering-things
 [capabilities]: ../datastorage/capabilities.md

--- a/docs/conventions/locations.md
+++ b/docs/conventions/locations.md
@@ -11,26 +11,26 @@ The `mods.toml` file is in the `./META-INF/` directory.
 
 ### Blockstates
 
-Blockstate definition files are in the JSON format and are in the `./assets/<modid>/blockstates/` folder.
+Blockstate definition files are JSONs within `./assets/<modid>/blockstates/` folder.
 
 ### Localizations
 
-[Localizations][i18n] are plain-text files with the file extension `.json` and the name being their [language code][langcode] in lowercase such as `en_us`.
+[Localizations][i18n] are JSONs named after their lowercased [language code][langcode], such as `en_us`.
 
 They are located in the `./assets/<modid>/lang/` folder.
 
 ### Models
 
-Model files are in JSON format and are located in `./assets/<modid>/models/block/` or `./assets/<modid>/models/item/` depending on whether they are for a block or an item, respectively.
+Model files are JSONs located within `./assets/<modid>/models/block/` or `./assets/<modid>/models/item/` depending on whether they are for a block or an item, respectively.
 
 ### Textures
 
-Textures are in the PNG format and are located in `./assets/<modid>/textures/blocks/` or `./assets/<modid>/textures/items/` depending on whether they are for a block or an item, respectively.
+Textures are PNGs located within `./assets/<modid>/textures/block/` or `./assets/<modid>/textures/item/` depending on whether they are for a block or an item, respectively.
 
 ### Recipes
 
-[Recipes][Recipes] are in JSON format and are located in `./data/<modid>/recipes/`.
+[Recipes][recipes] are JSONs located within `./data/<modid>/recipes/`.
 
-[Recipes]: ../utilities/recipes.md
-[langcode]: https://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx
 [i18n]: ../concepts/internationalization.md
+[langcode]: https://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx
+[recipes]: ../utilities/recipes.md

--- a/docs/conventions/versioning.md
+++ b/docs/conventions/versioning.md
@@ -1,12 +1,12 @@
 Versioning
 ==========
 
-In general projects, [Semantic Versioning](https://semver.org/) is often used (which has the format `MAJOR.MINOR.PATCH`). However, in the case of modding it may be more beneficial to use the format `MCVERSION-MAJORMOD.MAJORAPI.MINOR.PATCH`, to be able to differentiate between world-breaking and API-breaking changes of a mod.
+In general projects, [Semantic Versioning][semver] is often used (which has the format `MAJOR.MINOR.PATCH`). However, in the case of modding it may be more beneficial to use the format `MCVERSION-MAJORMOD.MAJORAPI.MINOR.PATCH` to be able to differentiate between world-breaking and API-breaking changes of a mod.
 
 Examples
 --------
 
-Here is a (most likely incomplete) list of things that increment the various variables.
+Here is a list of examples that can increment the various variables.
 
 * `MCVERSION`
 	* Always matches the Minecraft version the mod is for.
@@ -29,7 +29,7 @@ When incrementing any variable, all lesser variables should reset to `0`. For in
 
 ### Work In Progress
 
-If you are in the initial development stage of your mod (before any official releases), the `MAJORMOD` and `MAJORAPI` should always be `0`. Only `MINOR` should be updated every time you build your mod. Once you build an official release (most of the time with a stable API), you should increment `MAJORMOD` to version `1.0.0.0`. For any further development stages, refer to the [Prereleases](#prereleases) and [Release candidates](#release-candidates) section of this document.
+If you are in the initial development stage of your mod (before any official releases), the `MAJORMOD` and `MAJORAPI` should always be `0`. Only `MINOR` and `PATCH` should be updated every time you build your mod. Once you build an official release (most of the time with a stable API), you should increment `MAJORMOD` to version `1.0.0.0`. For any further development stages, refer to the [Prereleases][pre] and [Release candidates][rc] section of this document.
 
 ### Multiple Minecraft Versions
 
@@ -41,8 +41,12 @@ When dropping support for a Minecraft version, the last build for that version s
 
 ### Pre-releases
 
-It is also possible to prerelease work-in-progress features, which means new features are released that are not quite done yet. These can be seen as a sort of "beta". These versions should be appended with `-betaX`, where X is the number of the prerelease. (This guide does not use `-pre` since, at the time of writing, it is not a valid alias for `-beta` according to Forge.) Note that already released versions and versions before the initial release can not go into prerelease; variables (mostly `MINOR`, but `MAJORAPI` and `MAJORMOD` can also prerelease) should be updated accordingly before adding the `-beta` suffix. Versions before the initial release are simply work-in-progress builds.
+It is also possible to prerelease work-in-progress features, which means new features are released that are not quite done yet. These can be seen as a sort of "beta". These versions should be appended with `-betaX`, where `X` is the number of the prerelease. (This guide does not use `-pre` since, at the time of writing, it is not a valid alias for `-beta`.) Note that already released versions and versions before the initial release can not go into prerelease; variables (mostly `MINOR`, but `MAJORAPI` and `MAJORMOD` can also prerelease) should be updated accordingly before adding the `-beta` suffix. Versions before the initial release are simply work-in-progress builds.
 
 ### Release Candidates
 
 Release candidates act as prereleases before an actual version change. These versions should be appended with `-rcX`, where `X` is the number of the release candidate which should, in theory, only be increased for bugfixes. Already released versions can not receive release candidates; variables (mostly `MINOR`, but `MAJORAPI` and `MAJORMOD` can also prerelease)  should be updated accordingly before adding the `-rc` suffix. When releasing a release candidate as stable build, it can either be exactly the same as the last release candidate or have a few more bug fixes.
+
+[semver]: https://semver.org/
+[pre]: #pre-releases
+[rc]: #release-candidates


### PR DESCRIPTION
This is a cleanup of the conventions folder to address any syntax, formatting, and outdated information in the docs.

- There will be another PR for 1.16 to address the changes in the use of DeferredWorkQueue.
- Locations should be updated to include all the new assets and data subfolders after omnibus.