### PR TITLE
Porting Cleanup

### DIFF
--- a/docs/legacy/index.md
+++ b/docs/legacy/index.md
@@ -1,7 +1,7 @@
 Documentation for Legacy Versions
 =================================
 
-Forge has existed for years and you can still easily access builds of Forge for Minecraft versions as old as Minecraft 1.1. There are significant differences between each and every version and it would be an impossible task to support so many different versions. Therefore, Forge uses an LTS system where a previous major Minecraft version is deemed as "LTS" (Long Term Support). Only the latest version and any current LTS versions will have easily accessible documentation and be included in the version dropdown in the sidebar. However, some older versions were LTS once or the latest version at some point and had documentation written, links to old sites with documentation for those versions can be found here.
+Forge has existed for years, and you can still easily access builds of Forge for Minecraft versions as old as Minecraft 1.1. There are significant differences between each and every version, and it would be an impossible task to support so many different versions. Therefore, Forge uses an LTS system where a previous major Minecraft version is deemed as "LTS" (Long Term Support). Only the latest version and any current LTS versions will have easily accessible documentation and be included in the version dropdown in the sidebar. However, some older versions were LTS once or the latest version at some point and had documentation written. Links to old sites with documentation for those versions can be found here.
 
 !!! important
 
@@ -10,9 +10,10 @@ Forge has existed for years and you can still easily access builds of Forge for 
 
 ### List of Previously Documented versions
 
-Unfortunately not all versions were used for a significant amount of time and the documentation for that version may be incomplete. Whenever a new version is released the documentation from the previous version is copied and adjusted over time to include new and updated information. When a version wasn't supported for long the information was never updated, the accuracy percentages represent how much of the information that should have been updated was actually updated.
+Unfortunately, not all versions were used for a significant amount of time, and the documentation for that version may be incomplete. Whenever a new version is released, the documentation from the previous version is copied and adjusted over time to include new and updated information. When a version wasn't supported for long, the information was never updated. The accuracy percentages represent how much of the information that should have been updated was actually updated.
 
 |    Version    |  Accuracy  |                  Link                     |
 |:-------------:|:----------:|:------------------------------------------|
 |    1.12.x     |   100%     | https://mcforge.readthedocs.io/en/1.12.x/ |
 |    1.13.x     |    10%     | https://mcforge.readthedocs.io/en/1.13.x/ |
+|    1.14.x     |    10%     | https://mcforge.readthedocs.io/en/1.14.x/ |

--- a/docs/legacy/porting.md
+++ b/docs/legacy/porting.md
@@ -1,0 +1,12 @@
+Porting to Minecraft 1.15
+=========================
+
+Here you can find a list of primers on how to port from old versions to the current version. Some versions are lumped together since that particular version never saw much usage.
+
+|    From -> To     |               Primer               |
+|:-----------------:|:-----------------------------------|
+| 1.12 -> 1.13/1.14 | [Primer by williewillus][112to114] |
+| 1.14 -> 1.15      | [Primer by williewillus][114to115] |
+
+[112to114]: https://gist.github.com/williewillus/353c872bcf1a6ace9921189f6100d09a
+[114to115]: https://gist.github.com/williewillus/30d7e3f775fe93c503bddf054ef3f93e

--- a/docs/legacy/porting1415.md
+++ b/docs/legacy/porting1415.md
@@ -1,6 +1,0 @@
-Porting from Minecraft 1.13/1.14 to Minecraft 1.15
-==================================================
-
-Due to major rewrites to Forge happening during the lifetime of 1.13 it never saw much usage and instead most mods ported directly to 1.14 skipping over 1.13. Therefore this guide will focus on porting from 1.14 directly to 1.15.
-
-_Full documentation on porting from 1.14 to 1.15 is still work in progress, for now we suggest having a look at [a primer written by williewillus](https://gist.github.com/williewillus/30d7e3f775fe93c503bddf054ef3f93e)!_

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,7 +71,7 @@ nav:
     - PR Guidelines: 'forgedev/prguidelines.md'
   - Legacy Versions:
     - Home: 'legacy/index.md'
-    - Porting from 1.13/1.14 to 1.15: 'legacy/porting1415.md'
+    - Porting to 1.15: 'legacy/porting.md'
 
 # Do not edit in PRs below here
 site_name: Forge Documentation


### PR DESCRIPTION
This is a cleanup of the legacy folder to address any syntax, formatting, and outdated information in the docs.

- Porting has been updated to generalize the namespace for usage later on. We want to give aid to those updating from any old versions, so all primers shall be listed similar to old docs.
- There will be another PR to add the legacy data for 1.16 and the eventual primer.