### PR TITLE
[1.15.x] Fix outdated references in SimpleImpl Documentation

### DIFF
--- a/docs/networking/simpleimpl.md
+++ b/docs/networking/simpleimpl.md
@@ -53,7 +53,7 @@ There are a couple things to highlight in a packet handler. A packet handler has
 public static void handle(MyMessage msg, Supplier<NetworkEvent.Context> ctx) {
     ctx.get().enqueueWork(() -> {
         // Work that needs to be thread-safe (most work)
-        EntityPlayerMP sender = ctx.get().getSender(); // the client that sent this packet
+        ServerPlayerEntity sender = ctx.get().getSender(); // the client that sent this packet
         // Do stuff
     });
     ctx.get().setPacketHandled(true);


### PR DESCRIPTION
Fixes an old MCP class name in the SimpleImpl documentation as requested by ChampionAsh.